### PR TITLE
feat: scaffold core modules for MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
-# accountable
+# Accountable
+
+Accountable ist ein leichtgewichtiges Lernwerkzeug, das lokale Aufgabenverwaltung mit punktueller KI-Unterstützung verbindet.
+
+## MVP Features
+
+### 1. Lokale To-Do/Notiz-Funktion
+- Aufgaben hinzufügen, optional einem Lehrpfad zuordnen
+- Checkbox zum Abhaken
+- Optionales Datum und Wiederholung
+
+### 2. Lehrpfade / Phasen
+- Lehrpfade manuell anlegen (Name, Ziel, Beschreibung)
+- Jede Phase enthält eine Aufgabenliste
+- Subjektiver Abschluss über den Button "Ich habe es verinnerlicht"
+
+### 3. Tagesansicht
+- Zeigt heutige fällige Aufgaben
+- Aktive Phasen mit Fortschritt
+- Reflexionsfrage des Tages
+
+### 4. KI-Integration
+- Beim Erstellen eines neuen Lehrplans: Thema/Ziel eingeben → KI generiert Basisplan (Phasen + Aufgaben)
+- Bei Reflexionen: KI liefert Zusammenfassung oder Mustererkennung
+- Button „Neue Aufgabe vorschlagen“ für kontextbasierte KI-Ideen
+
+## UX-Fluss
+- **Home (Heute):** tägliche Aufgaben, aktive Phasen, Reflexionsfrage
+- **Add Task / Lehrplan:** Modal mit KI-Vorschlagsknopf
+- **Lehrpfade:** Kartenansicht aller Tracks → Phasenübersicht → Aufgaben & Reflexion
+- **Reflexion:** Text- oder Audioeingabe mit optionaler KI-Zusammenfassung
+
+## Architektur
+- **Frontend:** Flutter (Android & iOS)
+- **Datenhaltung:** lokal (SQLite oder Hive)
+- **KI-API:** OpenAI oder Claude, nur bei Bedarf aufgerufen
+- **Benachrichtigungen:** `flutter_local_notifications`
+- Clean, modulare Architektur mit separaten KI-Services
+
+## MVP-Fahrplan
+1. Woche 1–2: Basis-App (To-Do, Lehrpfade, Phasen)
+2. Woche 3: Tagesansicht + Reflexionssystem
+3. Woche 4: KI-Integration für Planerstellung & Reflexionsauswertung
+4. Woche 5: Benachrichtigungen, Bugfixes, kleiner Launch (Android)
+5. Woche 6–8: Feedback sammeln, evtl. iOS-Port, KI-Features erweitern
+
+
+## Entwicklung
+Dieses Repository enthält jetzt erste Kernmodule (Datenbank, Modelle, KI-Stub).
+
+### Voraussetzungen
+- Python 3.10+
+
+### Tests
+```bash
+pytest
+```
+
+### CLI ausprobieren
+```bash
+python -m accountable.cli add-task "Beispielaufgabe" --due-date 2024-01-01
+python -m accountable.cli list-due --date 2024-01-01
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "accountable"
+version = "0.1.0"
+description = "MVP core modules for Accountable app"
+authors = [{name = "Accountable Team"}]
+requires-python = ">=3.10"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/src/accountable/__init__.py
+++ b/src/accountable/__init__.py
@@ -1,0 +1,6 @@
+"""Core modules for Accountable MVP."""
+
+from .db import Database
+from .models import Task, Phase
+
+__all__ = ["Database", "Task", "Phase"]

--- a/src/accountable/ai.py
+++ b/src/accountable/ai.py
@@ -1,0 +1,38 @@
+"""Lightweight AI service using OpenAI's API.
+
+The service is optional and only activated when an API key is provided.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+try:
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    openai = None
+
+
+class AiClient:
+    def __init__(self, api_key: Optional[str] = None) -> None:
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        if openai and self.api_key:
+            openai.api_key = self.api_key
+
+    def _chat(self, prompt: str) -> str:
+        if not openai or not self.api_key:
+            raise RuntimeError("OpenAI not configured")
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.choices[0].message["content"].strip()
+
+    def generate_plan(self, topic: str) -> str:
+        """Generate a basic learning plan for the given topic."""
+        return self._chat(f"Create a concise learning plan for {topic}.")
+
+    def summarize_reflection(self, text: str) -> str:
+        """Return a short summary of the reflection text."""
+        return self._chat(f"Summarize the following reflection:\n{text}")

--- a/src/accountable/cli.py
+++ b/src/accountable/cli.py
@@ -1,0 +1,41 @@
+"""Simple command line interface for experimenting with the core module."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+
+from .db import Database
+from .models import Task
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Accountable CLI")
+    sub = parser.add_subparsers(dest="cmd")
+
+    add_task = sub.add_parser("add-task", help="Add a new task")
+    add_task.add_argument("description", help="Task description")
+    add_task.add_argument("--due-date", help="Due date in YYYY-MM-DD format")
+
+    list_due = sub.add_parser("list-due", help="List tasks due by date")
+    list_due.add_argument("--date", required=True, help="Date in YYYY-MM-DD format")
+
+    args = parser.parse_args()
+    db = Database("accountable.db")
+
+    if args.cmd == "add-task":
+        due = date.fromisoformat(args.due_date) if args.due_date else None
+        task = db.add_task(Task(description=args.description, due_date=due))
+        print(f"Created task {task.id}")
+    elif args.cmd == "list-due":
+        day = date.fromisoformat(args.date)
+        for task in db.get_due_tasks(day):
+            status = "done" if task.completed else "open"
+            due = task.due_date.isoformat() if task.due_date else ""
+            print(f"[{task.id}] {task.description} ({due}) - {status}")
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/accountable/db.py
+++ b/src/accountable/db.py
@@ -1,0 +1,98 @@
+"""SQLite-backed storage for tasks and phases."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import date
+from typing import Iterable, List
+
+from .models import Phase, Task
+
+
+class Database:
+    def __init__(self, path: str = ":memory:") -> None:
+        self.conn = sqlite3.connect(path)
+        self.conn.row_factory = sqlite3.Row
+        self._create_tables()
+
+    def _create_tables(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS phases (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                objective TEXT,
+                description TEXT,
+                completed INTEGER NOT NULL
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tasks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                description TEXT NOT NULL,
+                due_date DATE,
+                completed INTEGER NOT NULL,
+                phase_id INTEGER,
+                FOREIGN KEY(phase_id) REFERENCES phases(id)
+            )
+            """
+        )
+        self.conn.commit()
+
+    # Phase operations
+    def add_phase(self, phase: Phase) -> Phase:
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO phases (name, objective, description, completed) VALUES (?, ?, ?, ?)",
+            (phase.name, phase.objective, phase.description, int(phase.completed)),
+        )
+        phase.id = cur.lastrowid
+        self.conn.commit()
+        return phase
+
+    # Task operations
+    def add_task(self, task: Task) -> Task:
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO tasks (description, due_date, completed, phase_id) VALUES (?, ?, ?, ?)",
+            (
+                task.description,
+                task.due_date.isoformat() if task.due_date else None,
+                int(task.completed),
+                task.phase_id,
+            ),
+        )
+        task.id = cur.lastrowid
+        self.conn.commit()
+        return task
+
+    def complete_task(self, task_id: int) -> None:
+        cur = self.conn.cursor()
+        cur.execute("UPDATE tasks SET completed = 1 WHERE id = ?", (task_id,))
+        self.conn.commit()
+
+    def get_due_tasks(self, for_date: date) -> List[Task]:
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT id, description, due_date, completed, phase_id FROM tasks WHERE due_date <= ? AND completed = 0",
+            (for_date.isoformat(),),
+        )
+        rows = cur.fetchall()
+        tasks: List[Task] = []
+        for row in rows:
+            tasks.append(
+                Task(
+                    id=row["id"],
+                    description=row["description"],
+                    due_date=date.fromisoformat(row["due_date"]) if row["due_date"] else None,
+                    completed=bool(row["completed"]),
+                    phase_id=row["phase_id"],
+                )
+            )
+        return tasks
+
+    def close(self) -> None:
+        self.conn.close()

--- a/src/accountable/models.py
+++ b/src/accountable/models.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional
+
+
+@dataclass
+class Task:
+    """Represents a single task in a learning phase."""
+
+    description: str
+    due_date: Optional[date] = None
+    completed: bool = False
+    phase_id: Optional[int] = None
+    id: Optional[int] = None
+
+
+@dataclass
+class Phase:
+    """A learning phase grouping multiple tasks."""
+
+    name: str
+    objective: str = ""
+    description: str = ""
+    completed: bool = False
+    id: Optional[int] = None

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,20 @@
+from datetime import date
+
+from accountable import Database, Phase, Task
+
+
+def test_add_and_complete_task(tmp_path):
+    db_file = tmp_path / "test.db"
+    db = Database(str(db_file))
+
+    phase = db.add_phase(Phase(name="Intro"))
+    task = db.add_task(Task(description="Read docs", due_date=date.today(), phase_id=phase.id))
+
+    due = db.get_due_tasks(date.today())
+    assert len(due) == 1
+    assert due[0].description == "Read docs"
+
+    db.complete_task(task.id)
+    assert db.get_due_tasks(date.today()) == []
+
+    db.close()


### PR DESCRIPTION
## Summary
- add dataclasses for tasks and phases with SQLite-backed persistence
- include optional OpenAI-based AI client and simple CLI
- document development workflow and testing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895e0cd1f88832c953ab4273760f03e